### PR TITLE
Add configuration backup module, plus some fixes.

### DIFF
--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -13,6 +13,9 @@ def authentication(url_base, auth_params, module, result):
     """Basic authentication on the API"""
     url = url_base + "auth"
     res = requests.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    # FIXME: For early versions of the 7.0 release, POST at the /auth URL wasn't yet supported.
+    #        The response comes back with 401 status code, but the body is completely blank and causes json decode errors.
+    #        There's probably a better way to handle these, right now they crash ansible into a traceback.
     msg = res.json()["status"]["info"][0]["message"]
     if res.status_code != 200:
         module.fail_json(msg=msg, **result)

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -41,6 +41,14 @@ def commit(url_base, auth_params, module, result):
 def execute_api(url, json_params, api_action, auth_params, module, result):
     """Takes the needed action to the API from the module"""
     match api_action:
+        case "get":
+            res = requests.get(
+                url,
+                auth=auth_params,
+                json=json_params,
+                verify=module.params["ssl_verify"],
+                timeout=10,
+            )
         case "put":
             res = requests.put(
                 url,
@@ -75,6 +83,7 @@ def execute_api(url, json_params, api_action, auth_params, module, result):
     if res.status_code == 200:
         result["changed"] = True
         result["output"] = json_params
+        result["response"] = res.text
         return
     msg = res.json()["status"]["info"][0]["message"]
     module.fail_json(msg=msg, **result)

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -5,44 +5,58 @@
 from __future__ import absolute_import, division, print_function
 import json
 import requests
+from collections import OrderedDict
 
 __metaclass__ = type
+# SonicOS 6.5 releases have an issue with order of the headers, so we need to force requests to use the right order.
+# For more details:  https://github.com/hornjo/sonicos/pull/5#issuecomment-2523443898
+# Also, in the requests library we can only do this with Session objects:  https://requests.readthedocs.io/en/latest/user/advanced/#header-ordering
+session = requests.Session()
+# This is the same default headers provided by requests, just in a different order.
+session.headers = OrderedDict([
+    ('Accept', '*/*'),
+    ('Accept-Encoding', requests.utils.DEFAULT_ACCEPT_ENCODING),
+    ('User-Agent', requests.utils.default_user_agent()),
+    ('Connection', 'keep-alive')
+])
+
+def raise_for_error(url, res, module, result, check_success=False):
+    if res.status_code != 200 or (check_success and res.json()["status"]["success"] is not True):
+        code = res.json()["status"]["info"][0]["code"]
+        msg = res.json()["status"]["info"][0]["message"]
+        text = 'Api call failed.... URL: %s, CODE: %s, MESSAGE: %s' % (url, code, msg)
+        module.fail_json(msg=text, **result)
 
 
 def authentication(url_base, auth_params, module, result):
     """Basic authentication on the API"""
     url = url_base + "auth"
-    res = requests.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
-    msg = res.json()["status"]["info"][0]["message"]
-    if res.status_code != 200:
-        module.fail_json(msg=msg, **result)
-    if res.json()["status"]["info"][0]["config_mode"] == "No":
+    res = session.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, res, module, result)
+    # SonicOS 6.5 API is automatically in config mode and doesn't return this field.
+    if 'config_mode' in res.json()["status"]["info"][0] and res.json()["status"]["info"][0]["config_mode"] == "No":
         configmode(url_base, auth_params, module, result)
 
 
 def configmode(url_base, auth_params, module, result):
     """Enter config mode"""
     url = url_base + "config-mode"
-    res = requests.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
-    msg = res.json()["status"]["info"][0]["message"]
-    if res.status_code != 200:
-        module.fail_json(msg=msg, **result)
+    res = session.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, res, module, result)
 
 
 def commit(url_base, auth_params, module, result):
     """Commits the changes to the API"""
     url = url_base + "config/pending"
-    res = requests.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
-    msg = res.json()["status"]["info"][0]["message"]
-    if res.status_code != 200 or res.json()["status"]["success"] is not True:
-        module.fail_json(msg=msg, **result)
+    res = session.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, res, module, result, check_success=True)
 
 
 def execute_api(url, json_params, api_action, auth_params, module, result):
     """Takes the needed action to the API from the module"""
     match api_action:
         case "get":
-            res = requests.get(
+            res = session.get(
                 url,
                 auth=auth_params,
                 json=json_params,
@@ -50,7 +64,7 @@ def execute_api(url, json_params, api_action, auth_params, module, result):
                 timeout=10,
             )
         case "put":
-            res = requests.put(
+            res = session.put(
                 url,
                 auth=auth_params,
                 json=json_params,
@@ -58,7 +72,7 @@ def execute_api(url, json_params, api_action, auth_params, module, result):
                 timeout=10,
             )
         case "patch":
-            res = requests.patch(
+            res = session.patch(
                 url,
                 auth=auth_params,
                 json=json_params,
@@ -66,7 +80,7 @@ def execute_api(url, json_params, api_action, auth_params, module, result):
                 timeout=10,
             )
         case "post":
-            res = requests.post(
+            res = session.post(
                 url,
                 auth=auth_params,
                 json=json_params,
@@ -74,19 +88,16 @@ def execute_api(url, json_params, api_action, auth_params, module, result):
                 timeout=10,
             )
         case "delete":
-            res = requests.delete(
+            res = session.delete(
                 url,
                 auth=auth_params,
                 verify=module.params["ssl_verify"],
                 timeout=10,
             )
-    if res.status_code == 200:
-        result["changed"] = True
-        result["output"] = json_params
-        result["response"] = res.content
-        return
-    msg = res.json()["status"]["info"][0]["message"]
-    module.fail_json(msg=msg, **result)
+    raise_for_error(url, res, module, result)
+    result["changed"] = True
+    result["output"] = json_params
+    result["response"] = res.content
 
 
 def sort_json(json_data):

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -24,7 +24,7 @@ def raise_for_error(url, res, module, result, check_success=False):
     if res.status_code != 200 or (check_success and res.json()["status"]["success"] is not True):
         code = res.json()["status"]["info"][0]["code"]
         msg = res.json()["status"]["info"][0]["message"]
-        text = 'Api call failed.... URL: %s, CODE: %s, MESSAGE: %s' % (url, code, msg)
+        text = 'API FAILURE:  URL: %s, FAILURE_CODE: %s, MESSAGE: %s' % (url, code, msg)
         module.fail_json(msg=text, **result)
 
 

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -83,7 +83,7 @@ def execute_api(url, json_params, api_action, auth_params, module, result):
     if res.status_code == 200:
         result["changed"] = True
         result["output"] = json_params
-        result["response"] = res.text
+        result["response"] = res.content
         return
     msg = res.json()["status"]["info"][0]["message"]
     module.fail_json(msg=msg, **result)

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -38,6 +38,13 @@ def authentication(url_base, auth_params, module, result):
         configmode(url_base, auth_params, module, result)
 
 
+def logout(url_base, auth_params, module):
+    """Logout from the API"""
+    url = url_base + "auth"
+    session.delete(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    # Ignore any failure response here, as the session is ending anyway.
+
+
 def configmode(url_base, auth_params, module, result):
     """Enter config mode"""
     url = url_base + "config-mode"

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -13,9 +13,6 @@ def authentication(url_base, auth_params, module, result):
     """Basic authentication on the API"""
     url = url_base + "auth"
     res = requests.post(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
-    # FIXME: For early versions of the 7.0 release, POST at the /auth URL wasn't yet supported.
-    #        The response comes back with 401 status code, but the body is completely blank and causes json decode errors.
-    #        There's probably a better way to handle these, right now they crash ansible into a traceback.
     msg = res.json()["status"]["info"][0]["message"]
     if res.status_code != 200:
         module.fail_json(msg=msg, **result)

--- a/plugins/module_utils/sonicos_core_functions.py
+++ b/plugins/module_utils/sonicos_core_functions.py
@@ -61,46 +61,45 @@ def commit(url_base, auth_params, module, result):
 
 def execute_api(url, json_params, api_action, auth_params, module, result):
     """Takes the needed action to the API from the module"""
-    match api_action:
-        case "get":
-            res = session.get(
-                url,
-                auth=auth_params,
-                json=json_params,
-                verify=module.params["ssl_verify"],
-                timeout=10,
-            )
-        case "put":
-            res = session.put(
-                url,
-                auth=auth_params,
-                json=json_params,
-                verify=module.params["ssl_verify"],
-                timeout=10,
-            )
-        case "patch":
-            res = session.patch(
-                url,
-                auth=auth_params,
-                json=json_params,
-                verify=module.params["ssl_verify"],
-                timeout=10,
-            )
-        case "post":
-            res = session.post(
-                url,
-                auth=auth_params,
-                json=json_params,
-                verify=module.params["ssl_verify"],
-                timeout=10,
-            )
-        case "delete":
-            res = session.delete(
-                url,
-                auth=auth_params,
-                verify=module.params["ssl_verify"],
-                timeout=10,
-            )
+    if api_action == "get":
+        res = session.get(
+            url,
+            auth=auth_params,
+            json=json_params,
+            verify=module.params["ssl_verify"],
+            timeout=10,
+        )
+    if api_action == "put":
+        res = session.put(
+            url,
+            auth=auth_params,
+            json=json_params,
+            verify=module.params["ssl_verify"],
+            timeout=10,
+        )
+    if api_action == "patch":
+        res = session.patch(
+            url,
+            auth=auth_params,
+            json=json_params,
+            verify=module.params["ssl_verify"],
+            timeout=10,
+        )
+    if api_action == "post":
+        res = session.post(
+            url,
+            auth=auth_params,
+            json=json_params,
+            verify=module.params["ssl_verify"],
+            timeout=10,
+        )
+    if api_action == "delete":
+        res = session.delete(
+            url,
+            auth=auth_params,
+            verify=module.params["ssl_verify"],
+            timeout=10,
+        )
     raise_for_error(url, res, module, result)
     result["changed"] = True
     result["output"] = json_params

--- a/plugins/modules/sonicos_access_rules.py
+++ b/plugins/modules/sonicos_access_rules.py
@@ -306,7 +306,7 @@ module = AnsibleModule(
 
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining actual module functions

--- a/plugins/modules/sonicos_access_rules.py
+++ b/plugins/modules/sonicos_access_rules.py
@@ -39,7 +39,7 @@ options:
         required: True
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is True.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is True.
         required: False
         type: bool
         default: True

--- a/plugins/modules/sonicos_access_rules.py
+++ b/plugins/modules/sonicos_access_rules.py
@@ -14,6 +14,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     compare_json,
     session,
     raise_for_error,
+    logout,
 )
 
 __metaclass__ = type
@@ -568,6 +569,8 @@ def main():
     access_rules()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_access_rules.py
+++ b/plugins/modules/sonicos_access_rules.py
@@ -12,6 +12,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     commit,
     execute_api,
     compare_json,
+    session,
+    raise_for_error,
 )
 
 __metaclass__ = type
@@ -459,9 +461,10 @@ def get_address_type(address_name):
         for address_kind in "objects", "groups":
             var_helper = "address_" + address_kind
             url = url_base + "address-" + address_kind + "/" + ip_version
-            req = requests.get(
+            req = session.get(
                 url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10
             )
+            raise_for_error(url, req, module, result)
 
             if var_helper in req.json():
                 for item in req.json()[var_helper]:
@@ -477,7 +480,8 @@ def get_service_type(service_name):
     """Determinig the type for source and detination service"""
     service_type = "name"
     url = url_base + "service-groups"
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if "service_groups" in req.json():
         for item in req.json()["service_groups"]:
@@ -497,7 +501,8 @@ def access_rules():
     if module.params["state"] == "present":
         api_action = "post"
 
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if "access_rules" in req.json():
         for item in req.json()["access_rules"]:

--- a/plugins/modules/sonicos_address_groups.py
+++ b/plugins/modules/sonicos_address_groups.py
@@ -15,6 +15,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     compare_json,
     session,
     raise_for_error,
+    logout,
 )
 
 
@@ -333,6 +334,8 @@ def main():
     address_group()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_address_groups.py
+++ b/plugins/modules/sonicos_address_groups.py
@@ -184,7 +184,7 @@ module = AnsibleModule(
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
 url_address_groups = url_base + "address-groups/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining actual module functions

--- a/plugins/modules/sonicos_address_groups.py
+++ b/plugins/modules/sonicos_address_groups.py
@@ -13,6 +13,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     commit,
     execute_api,
     compare_json,
+    session,
+    raise_for_error,
 )
 
 
@@ -196,7 +198,8 @@ def get_address_member_type(address_member_name, address_object_kind):
     if address_object_kind != "address_group":
         url = url_base + "address-objects/ipv6"
 
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     flat_req = flatten(req.json())
 
@@ -273,7 +276,8 @@ def address_group():
 
     for ip_version in ip_versions:
         url = url_address_groups + ip_version
-        req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+        req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+        raise_for_error(url, req, module, result)
 
         if "address_groups" in req.json():
             for item in req.json()["address_groups"]:

--- a/plugins/modules/sonicos_address_groups.py
+++ b/plugins/modules/sonicos_address_groups.py
@@ -41,7 +41,7 @@ options:
         required: true
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is true.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
         required: false
         type: bool
         default: true

--- a/plugins/modules/sonicos_address_objects.py
+++ b/plugins/modules/sonicos_address_objects.py
@@ -250,7 +250,7 @@ module = AnsibleModule(
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
 url_address_objects = url_base + "address-objects/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining actual module functions

--- a/plugins/modules/sonicos_address_objects.py
+++ b/plugins/modules/sonicos_address_objects.py
@@ -11,6 +11,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     authentication,
     commit,
     execute_api,
+    session,
+    raise_for_error,
 )
 
 __metaclass__ = type
@@ -301,7 +303,8 @@ def address_object():
     api_action = None
 
     json_params = get_json_params(ip_type)
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if module.params["state"] == "present":
         api_action = "post"

--- a/plugins/modules/sonicos_address_objects.py
+++ b/plugins/modules/sonicos_address_objects.py
@@ -38,7 +38,7 @@ options:
         required: true
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is true.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
         required: false
         type: bool
         default: true

--- a/plugins/modules/sonicos_address_objects.py
+++ b/plugins/modules/sonicos_address_objects.py
@@ -13,6 +13,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     execute_api,
     session,
     raise_for_error,
+    logout,
 )
 
 __metaclass__ = type
@@ -344,6 +345,8 @@ def main():
     address_object()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_address_objects.py
+++ b/plugins/modules/sonicos_address_objects.py
@@ -271,24 +271,23 @@ def get_json_params(ip_type):
     }
     dict_object_type = json_params["address_objects"][0][ip_type]
 
-    match module.params["object_type"]:
-        case "host":
-            dict_object_type["host"] = {"ip": module.params["ip"]}
-        case "range":
-            dict_object_type["range"] = {
-                "begin": module.params["ip_range"]["begin"],
-                "end": module.params["ip_range"]["end"],
-            }
-        case "network":
-            dict_object_type["network"] = {
-                "subnet": module.params["network"]["subnet"],
-                "mask": module.params["network"]["mask"],
-            }
-        case "mac":
-            dict_object_type["address"] = module.params["mac"].replace(":", "").upper()
-            dict_object_type["multi_homed"] = module.params["multi_homed"]
-        case "fqdn":
-            dict_object_type["domain"] = module.params["fqdn"]
+    if module.params["object_type"] == "host":
+        dict_object_type["host"] = {"ip": module.params["ip"]}
+    if module.params["object_type"] == "range":
+        dict_object_type["range"] = {
+            "begin": module.params["ip_range"]["begin"],
+            "end": module.params["ip_range"]["end"],
+        }
+    if module.params["object_type"] == "network":
+        dict_object_type["network"] = {
+            "subnet": module.params["network"]["subnet"],
+            "mask": module.params["network"]["mask"],
+        }
+    if module.params["object_type"] == "mac":
+        dict_object_type["address"] = module.params["mac"].replace(":", "").upper()
+        dict_object_type["multi_homed"] = module.params["multi_homed"]
+    if module.params["object_type"] == "fqdn":
+        dict_object_type["domain"] = module.params["fqdn"]
 
     return json_params
 

--- a/plugins/modules/sonicos_config_bkup.py
+++ b/plugins/modules/sonicos_config_bkup.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 import os
+import requests
 import urllib3
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functions import authentication, execute_api  # NOQA
@@ -108,7 +109,7 @@ module = AnsibleModule(
 
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining the actual module actions

--- a/plugins/modules/sonicos_config_bkup.py
+++ b/plugins/modules/sonicos_config_bkup.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+# Copyright: (c) 2023, Horn Johannes (@hornjo)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Ansible module code for interfaces"""
+
+from __future__ import absolute_import, division, print_function
+import os
+import urllib3
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functions import authentication, execute_api  # NOQA
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: sonicos_config_bkup
+
+short_description: Export the configuration from SonicWALL
+version_added: "1.0.0"
+description:
+- This brings the capability to authenticate and backup the device configuration, in either EXP or CLI format.
+- This module is only supported on sonicos 7 or newer
+options:
+    hostname:
+        description: Defines the endpoint of the sonicos.
+        required: true
+        type: str
+    username:
+        description: The username for the login and authentication.
+        required: true
+        type: str
+    password:
+        description: The password for the authentication and login.
+        required: true
+        type: str
+    ssl_verify:
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
+        required: false
+        type: bool
+        default: True
+    exp_format:
+        description: Backup in EXP format, instead of CLI format.
+        required: False
+        type: bool
+        default: False
+    filename:
+        description:
+            - Name of file in which the running-config will be saved.
+              If not specified, the filename will default to "backup" of .txt or .exp, for CLI or EXP type backups respectively.
+        required: False
+        type: str
+    dir_path:
+        description:
+            - Path to directory in which the backup file should reside.
+              If not specified, the backup file is written to the "backup" folder in the playbook root directory.
+              If the directory does not exist, it is created.
+        required: False
+        type: str
+
+
+author:
+    - Kelly Shutt (@CompPhy)
+"""
+
+EXAMPLES = r"""
+- name:  Create a backup of the device configuration into /tmp/config-backup/backup.txt on the Ansible controller, contents of the file will be in CLI export format.
+  hornjo.sonicos.sonicos_config_bkup:
+    hostname: 192.168.178.254
+    username: admin
+    password: password
+    ssl_verify: false
+    dir_path: /tmp/config-backup/
+"""
+
+RETURN = r"""
+result:
+    description: information about performed operation
+    returned: always
+    type: str
+    sample: {
+        "changed": false,
+        "failed": false,
+        "output": {}
+"""
+
+
+# Defining module arguments
+module_args = dict(
+    hostname=dict(type="str", required=True),
+    username=dict(type="str", required=True),
+    password=dict(type="str", required=True, no_log=True),
+    ssl_verify=dict(type="bool", default=True),
+    exp_format=dict(type="bool", required=False, default=False),
+    filename=dict(type="str", required=False, default=''),
+    dir_path=dict(type="path", required=False, default='')
+)
+
+# Defining registerable values
+result = dict(
+    changed=False
+)
+
+# Defining ansible settings
+module = AnsibleModule(
+    argument_spec=module_args,
+    supports_check_mode=False
+)
+
+# Defining global variables
+url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
+auth_params = (module.params["username"], module.params["password"])
+
+
+# Defining the actual module actions
+def main():
+    """Main function which calls the functions"""
+
+    if not module.params["ssl_verify"]:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    authentication(url_base, auth_params, module, result)
+
+    json_params = {}
+    api_action = 'get'
+    url = url_base + '/export/current-config/cli'
+    if module.params["exp_format"]:
+        url = url_base + '/export/current-config/exp'
+
+    if not module.params['dir_path']:
+        dir_path = './backup'
+
+    if not module.params['filename']:
+        filename = 'backup.txt'
+        if module.params['exp_format']:
+            filename = 'backup.exp'
+    
+    output_file = os.path.join(dir_path, filename)
+
+    execute_api(url, json_params, api_action, auth_params, module, result)
+
+    with open(output_file, 'w') as output:
+        output.write(result['response'])
+
+    module.exit_json(**result)
+
+
+# Executing the module
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/sonicos_config_bkup.py
+++ b/plugins/modules/sonicos_config_bkup.py
@@ -121,25 +121,27 @@ def main():
 
     authentication(url_base, auth_params, module, result)
 
-    json_params = {}
+    json_params = None
     api_action = 'get'
-    url = url_base + '/export/current-config/cli'
+    url = url_base + 'export/current-config/cli'
     if module.params["exp_format"]:
-        url = url_base + '/export/current-config/exp'
+        url = url_base + 'export/current-config/exp'
 
-    if not module.params['dir_path']:
-        dir_path = './backup'
+    dir_path = './backup'
+    if module.params['dir_path']:
+        dir_path = module.params['dir_path']
 
-    if not module.params['filename']:
-        filename = 'backup.txt'
-        if module.params['exp_format']:
-            filename = 'backup.exp'
+    filename = 'backup.txt'
+    if module.params['exp_format']:
+        filename = 'backup.exp'
+    if module.params['filename']:
+        filename = module.params['filename']
     
     output_file = os.path.join(dir_path, filename)
 
     execute_api(url, json_params, api_action, auth_params, module, result)
 
-    with open(output_file, 'w') as output:
+    with open(output_file, 'wb') as output:
         output.write(result['response'])
 
     module.exit_json(**result)

--- a/plugins/modules/sonicos_config_bkup.py
+++ b/plugins/modules/sonicos_config_bkup.py
@@ -8,7 +8,7 @@ import os
 import requests
 import urllib3
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functions import authentication, execute_api  # NOQA
+from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functions import authentication, execute_api, logout  # NOQA
 
 __metaclass__ = type
 
@@ -143,6 +143,8 @@ def main():
 
     with open(output_file, 'wb') as output:
         output.write(result['response'])
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_interfaces.py
+++ b/plugins/modules/sonicos_interfaces.py
@@ -192,7 +192,7 @@ module = AnsibleModule(
 
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining actual module functions

--- a/plugins/modules/sonicos_interfaces.py
+++ b/plugins/modules/sonicos_interfaces.py
@@ -14,6 +14,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     compare_json,
     session,
     raise_for_error,
+    logout,
 )
 
 __metaclass__ = type
@@ -426,6 +427,8 @@ def main():
     interfaces()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_interfaces.py
+++ b/plugins/modules/sonicos_interfaces.py
@@ -12,6 +12,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     commit,
     execute_api,
     compare_json,
+    session,
+    raise_for_error,
 )
 
 __metaclass__ = type
@@ -349,11 +351,8 @@ def interfaces():
     if module.params["state"] == "present":
         api_action = "post"
 
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
-
-    # Debug
-    # module.fail_json(msg=json_params, **result)
-    # module.fail_json(msg=req.json(), **result)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if "interfaces" in req.json():
         for item in req.json()["interfaces"]:
@@ -398,13 +397,14 @@ def interfaces():
 
                 # module.fail_json(msg=tmp_json_params, **result)
 
-                requests.patch(
+                req = session.patch(
                     url,
                     auth=auth_params,
                     json=tmp_json_params,
                     verify=module.params["ssl_verify"],
                     timeout=10,
                 )
+                raise_for_error(url, req, module, result)
                 commit(url_base, auth_params, module, result)
 
     # Debug

--- a/plugins/modules/sonicos_interfaces.py
+++ b/plugins/modules/sonicos_interfaces.py
@@ -39,7 +39,7 @@ options:
         required: true
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is true.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
         required: false
         type: bool
         default: True

--- a/plugins/modules/sonicos_service_groups.py
+++ b/plugins/modules/sonicos_service_groups.py
@@ -12,6 +12,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     commit,
     execute_api,
     compare_json,
+    session,
+    raise_for_error,
 )
 
 __metaclass__ = type
@@ -197,7 +199,8 @@ def service_groups():
     if module.params["state"] == "present":
         api_action = "post"
 
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if "service_groups" in req.json():
         for item in req.json()["service_groups"]:

--- a/plugins/modules/sonicos_service_groups.py
+++ b/plugins/modules/sonicos_service_groups.py
@@ -161,7 +161,7 @@ module = AnsibleModule(
 
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining actual module functions

--- a/plugins/modules/sonicos_service_groups.py
+++ b/plugins/modules/sonicos_service_groups.py
@@ -39,7 +39,7 @@ options:
         required: true
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is true.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
         required: false
         type: bool
         default: true

--- a/plugins/modules/sonicos_service_groups.py
+++ b/plugins/modules/sonicos_service_groups.py
@@ -14,6 +14,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     compare_json,
     session,
     raise_for_error,
+    logout,
 )
 
 __metaclass__ = type
@@ -237,6 +238,8 @@ def main():
     service_groups()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_service_objects.py
+++ b/plugins/modules/sonicos_service_objects.py
@@ -11,6 +11,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     authentication,
     commit,
     execute_api,
+    session,
+    raise_for_error,
 )
 
 __metaclass__ = type
@@ -247,7 +249,8 @@ def service_objects():
     if module.params["state"] == "present":
         api_action = "post"
 
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if "service_objects" in req.json():
         for item in req.json()["service_objects"]:

--- a/plugins/modules/sonicos_service_objects.py
+++ b/plugins/modules/sonicos_service_objects.py
@@ -13,6 +13,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     execute_api,
     session,
     raise_for_error,
+    logout,
 )
 
 __metaclass__ = type
@@ -284,6 +285,8 @@ def main():
     service_objects()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_service_objects.py
+++ b/plugins/modules/sonicos_service_objects.py
@@ -194,7 +194,7 @@ module = AnsibleModule(
 
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 # Defining actual module functions

--- a/plugins/modules/sonicos_service_objects.py
+++ b/plugins/modules/sonicos_service_objects.py
@@ -38,7 +38,7 @@ options:
         required: true
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is true.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
         required: false
         type: bool
         default: true

--- a/plugins/modules/sonicos_zones.py
+++ b/plugins/modules/sonicos_zones.py
@@ -215,7 +215,7 @@ module = AnsibleModule(
 
 # Defining global variables
 url_base = "https://" + module.params["hostname"] + "/api/sonicos/"
-auth_params = (module.params["username"], module.params["password"])
+auth_params = requests.auth.HTTPDigestAuth(module.params["username"], module.params["password"])
 
 
 def get_json_params():

--- a/plugins/modules/sonicos_zones.py
+++ b/plugins/modules/sonicos_zones.py
@@ -13,6 +13,7 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     execute_api,
     session,
     raise_for_error,
+    logout,
 )
 
 
@@ -316,6 +317,8 @@ def main():
     zones()
 
     commit(url_base, auth_params, module, result)
+
+    logout(url_base, auth_params, module)
 
     module.exit_json(**result)
 

--- a/plugins/modules/sonicos_zones.py
+++ b/plugins/modules/sonicos_zones.py
@@ -11,6 +11,8 @@ from ansible_collections.hornjo.sonicos.plugins.module_utils.sonicos_core_functi
     authentication,
     commit,
     execute_api,
+    session,
+    raise_for_error,
 )
 
 
@@ -264,7 +266,8 @@ def zones():
     if module.params["state"] == "present":
         api_action = "post"
 
-    req = requests.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    req = session.get(url, auth=auth_params, verify=module.params["ssl_verify"], timeout=10)
+    raise_for_error(url, req, module, result)
 
     if "zones" in req.json():
         for item in req.json()["zones"]:

--- a/plugins/modules/sonicos_zones.py
+++ b/plugins/modules/sonicos_zones.py
@@ -39,7 +39,7 @@ options:
         required: true
         type: str
     ssl_verify:
-        description: Defines whether you want to use thrusted ssl certification verfication or not. Default value is true.
+        description: Defines whether you want to use trusted ssl certification verfication or not. Default value is true.
         required: false
         type: bool
         default: true


### PR DESCRIPTION
First of all, thank you for starting this module.  I hope it can get to a point where it's in Galaxy soon.

This PR is intended to add a configuration backup module, which uses the /export/ API to get a copy of the current configuration and then writes this into a backup file.  It's a rather limited use case, but is great for doing things like automated periodic backups.  We want this as part of our DR plan going forward.

Along the way I found a few issues and fixed them:

1) Fixed a typo in multiple comments.
2) Added GET into the execute_api function, since this specific action was missing.
3) Added the response.content field into the result object, this allows to handling of the content later if needed.  It will also allow passing back up into the playbook if you register the results.
4) Switch to HTTP Digest Authentication.  We have devices running both 6.5 and 7.0 release of SonicOS, and they were being problematic with processing the authentication headers.  After switching to HTTPAuthDigest, as per Sonicwall recommendations in the documentation, all are working quite reliably now.
5) Updated some of the failure messages for better feedback when something goes wrong.
6) Fixed header failure messages when talking to 6.5.4 API.
7) Fixed failure messages when talking to 6.5.4 API, because it doesn't care about "config_mode" in the messages.
8) Added session logout when modules are done.
